### PR TITLE
Use Cabal-Version >=1.10

### DIFF
--- a/transformers-free.cabal
+++ b/transformers-free.cabal
@@ -1,6 +1,6 @@
 Name: transformers-free
 Version: 1.0.0
-Cabal-Version: >=1.14.0
+Cabal-Version: >=1.10
 Build-Type: Simple
 License: BSD3
 License-File: LICENSE


### PR DESCRIPTION
It is equivalent to Cabal-Version >= 1.14

Note: made a revision on Hackage: http://matrix.hackage.haskell.org/package/transformers-free
